### PR TITLE
fix: cached evaluations even without novating contracts

### DIFF
--- a/api/src/main/services/CacheService.ts
+++ b/api/src/main/services/CacheService.ts
@@ -52,7 +52,15 @@ class CacheService {
       throw new Error('Redis client not initialized');
     }
 
-    await this.redisClient.del(key.toLowerCase());
+    if (key.endsWith('.*')) {
+      const pattern = key.toLowerCase().slice(0, -2); // Remove the ".*" suffix
+      const keysToDelete = await this.redisClient.keys(`${pattern}*`);
+      if (keysToDelete.length > 0) {
+        await this.redisClient.del(keysToDelete);
+      }
+    } else {
+      await this.redisClient.del(key.toLowerCase());
+    }
   }
 }
 

--- a/api/src/main/services/ContractService.ts
+++ b/api/src/main/services/ContractService.ts
@@ -160,6 +160,7 @@ class ContractService {
     result.contractedServices = resetEscapeContractedServiceVersions(result.contractedServices);
     
     await this.cacheService.set(`contracts.${userId}`, result, 3600, true); // Cache for 1 hour
+    await this.cacheService.del(`features.${userId}.*`)
 
     return result;
   }
@@ -196,6 +197,7 @@ class ContractService {
     result.contractedServices = resetEscapeContractedServiceVersions(result.contractedServices);
     
     await this.cacheService.set(`contracts.${userId}`, result, 3600, true); // Cache for 1 hour
+    await this.cacheService.del(`features.${userId}.*`)
 
     return result;
   }
@@ -228,6 +230,7 @@ class ContractService {
     result.contractedServices = resetEscapeContractedServiceVersions(result.contractedServices);
     
     await this.cacheService.set(`contracts.${userId}`, result, 3600, true); // Cache for 1 hour
+    await this.cacheService.del(`features.${userId}.*`)
 
     return result;
   }
@@ -264,7 +267,8 @@ class ContractService {
     result.contractedServices = resetEscapeContractedServiceVersions(result.contractedServices);
     
     await this.cacheService.set(`contracts.${userId}`, result, 3600, true); // Cache for 1 hour
-    
+    await this.cacheService.del(`features.${userId}.*`)
+
     return result;
   }
 
@@ -309,7 +313,8 @@ class ContractService {
     updatedContract.contractedServices = resetEscapeContractedServiceVersions(updatedContract.contractedServices);
 
     await this.cacheService.set(`contracts.${userId}`, updatedContract, 3600, true); // Cache for 1 hour
-
+    await this.cacheService.del(`features.${userId}.*`)
+    
     return updatedContract;
   }
 


### PR DESCRIPTION
FIX:

- Delete feature evaluation cache every time a contract is novated